### PR TITLE
Add the CSP Policy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "classnames": "^2.3.1",
         "express": "^4.18.1",
         "font-awesome": "^4.7.0",
+        "helmet": "^7.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.3.0",
@@ -5605,11 +5606,14 @@
       }
     },
     "node_modules/@storybook/addon-controls/node_modules/watchpack/chokidar2": {
-      "version": "0.0.1",
+      "version": "2.0.0",
       "dev": true,
       "optional": true,
       "dependencies": {
         "chokidar": "^2.1.8"
+      },
+      "engines": {
+        "node": "<8.10.0"
       }
     },
     "node_modules/@storybook/addon-controls/node_modules/watchpack/chokidar2/node_modules/chokidar": {
@@ -26702,6 +26706,14 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-7.1.0.tgz",
+      "integrity": "sha512-g+HZqgfbpXdCkme/Cd/mZkV0aV3BZZZSugecH03kl38m/Kmdx8jKjBikpDj2cr+Iynv4KpYEviojNdTJActJAg==",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/hmac-drbg": {
@@ -63034,6 +63046,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+    },
+    "helmet": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-7.1.0.tgz",
+      "integrity": "sha512-g+HZqgfbpXdCkme/Cd/mZkV0aV3BZZZSugecH03kl38m/Kmdx8jKjBikpDj2cr+Iynv4KpYEviojNdTJActJAg=="
     },
     "hmac-drbg": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "classnames": "^2.3.1",
     "express": "^4.18.1",
     "font-awesome": "^4.7.0",
+    "helmet": "^7.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.3.0",

--- a/public/index.html
+++ b/public/index.html
@@ -9,15 +9,7 @@
       name="description"
       content="Web site created using create-react-app"
     />
-    <meta http-equiv="Content-Security-Policy" 
-      content="default-src 'self'; 
-               img-src 'self' data:;
-               script-src 'self'; 
-               style-src 'self' 'unsafe-inline'; 
-               font-src 'self';
-               connect-src 'self' http://localhost:5001;">
-
-
+ 
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,15 @@
       name="description"
       content="Web site created using create-react-app"
     />
+    <meta http-equiv="Content-Security-Policy" 
+      content="default-src 'self'; 
+               img-src 'self' data:;
+               script-src 'self'; 
+               style-src 'self' 'unsafe-inline'; 
+               font-src 'self';
+               connect-src 'self' http://localhost:5001;">
+
+
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/server.js
+++ b/server.js
@@ -16,6 +16,11 @@ app.use(helmet({
       fontSrc: ["'self'"],
     },
   },
+  frameguard: { action: 'deny' },
+  xssFilter: {},
+  noSniff: {},
+  ieNoOpen: {},
+  permittedCrossDomainPolicies: { permittedPolicies: 'none' },
 }));
 
 app.use(express.static(path.join(__dirname, directory)));

--- a/server.js
+++ b/server.js
@@ -1,8 +1,23 @@
 const express = require('express');
 const path = require('path');
+const helmet = require('helmet');
 
 const app = express();
 const directory = `/${process.env.STATIC_DIR || 'dist'}`;
+
+app.use(helmet({
+  contentSecurityPolicy: {
+    directives: {
+      defaultSrc: ["'self'"],
+      connectSrc: ["'self'", process.env.REACT_APP_BACKEND_HOST],
+      scriptSrc: ["'self'"],
+      styleSrc: ["'self'", "'unsafe-inline'"],
+      imgSrc: ["'self'", 'data:'],
+      fontSrc: ["'self'"],
+    },
+  },
+}));
+
 app.use(express.static(path.join(__dirname, directory)));
 
 // We want to use browserHistory


### PR DESCRIPTION
Ajout d'une CSP suite aux recommandations de l'audit de sécurité.
On fait ça côté serveur en utilisant helmet (https://github.com/helmetjs/helmet) qui permet de setter les headers des réponses HTTP.