### PR TITLE
endpoints no longer require convict id in params

### DIFF
--- a/src/pages/Agents.tsx
+++ b/src/pages/Agents.tsx
@@ -32,7 +32,7 @@ function Agents() {
     const fetchAgent = async () => {
       try {
         const resData = await sendRequest({
-          url: `${process.env.REACT_APP_BACKEND_HOST}/api/users/${user.msjId}/cpip`,
+          url: `${process.env.REACT_APP_BACKEND_HOST}/api/users/cpip`,
           method: 'GET',
           headers: {
             'Content-Type': 'application/json',

--- a/src/pages/Appointments.tsx
+++ b/src/pages/Appointments.tsx
@@ -23,7 +23,7 @@ function Appointments() {
     const fetchUserAppointments = async () => {
       try {
         const resData = await sendRequest({
-          url: `${process.env.REACT_APP_BACKEND_HOST}/api/appointments/${user.msjId}`,
+          url: `${process.env.REACT_APP_BACKEND_HOST}/api/appointments`,
           method: 'GET',
           headers: {
             'Content-Type': 'application/json',


### PR DESCRIPTION
As requested by security audit