### PR TITLE
Update DSFR to last version without bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@dataesr/react-dsfr": "^3.10.0",
-        "@gouvfr/dsfr": "^1.11.2",
+        "@gouvfr/dsfr": "1.9.1",
         "@jonkoops/matomo-tracker-react": "^0.7.0",
         "@testing-library/jest-dom": "^6.4.2",
         "@testing-library/react": "^14.3.0",
@@ -2486,11 +2486,11 @@
       }
     },
     "node_modules/@gouvfr/dsfr": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@gouvfr/dsfr/-/dsfr-1.11.2.tgz",
-      "integrity": "sha512-S7idT4rCCw6M1pqxJS8y4nUSq/Rus+Kucoifmv0CrZD/eoBA34HWqWYzR9GIxvtAX/TQ1XC7Hz+54THtVzMeqQ==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@gouvfr/dsfr/-/dsfr-1.9.1.tgz",
+      "integrity": "sha512-vZZpVRr32pW4YiclbWKPI7VGW85O012AE8tHFYgLhc96zzY5Zqp4rsDvwo3qt0GAn2/BSJoM3+MjXi0YFhbzmg==",
       "engines": {
-        "node": ">=18.16.1"
+        "node": ">=14.18.0"
       }
     },
     "node_modules/@hapi/hoek": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@dataesr/react-dsfr": "^3.10.0",
-    "@gouvfr/dsfr": "^1.11.2",
+    "@gouvfr/dsfr": "1.9.1",
     "@jonkoops/matomo-tracker-react": "^0.7.0",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^14.3.0",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,6 +12,7 @@ import '@gouvfr/dsfr/dist/utility/icons/icons-system/icons-system.css';
 import '@gouvfr/dsfr/dist/utility/icons/icons-user/icons-user.css';
 import '@gouvfr/dsfr/dist/utility/icons/icons-business/icons-business.css';
 
+import '@gouvfr/dsfr/dist/dsfr.module.min';
 import '@gouvfr/dsfr/dist/dsfr.nomodule.min';
 
 import 'remixicon/fonts/remixicon.css';


### PR DESCRIPTION
On ne peut pas upgrade plus haut pour la même raison qu'ici https://github.com/GouvernementFR/dsfr/issues/730